### PR TITLE
Added missing pods from update

### DIFF
--- a/src/components/Pins/ZeeReward.jsx
+++ b/src/components/Pins/ZeeReward.jsx
@@ -39,7 +39,10 @@ const ZeeReward = (props) => {
           <hr />
           <span className="mt-1"><span className="font-medium">Contents:</span> {treasurePod.contents}</span>
           <span><span className="font-medium">Description:</span> {treasurePod.description}</span>
-          <span className="mb-1"><span className="font-medium">Location:</span> <a href={treasurePod.embedd} target="_blank" rel="noreferrer noopener">Video showcase</a> by TrophyTom</span>
+          <span className="mb-1">
+            <span className="font-medium">Location:</span>
+            { treasurePod.embedded && <><a href={treasurePod.embedded} target="_blank" rel="noreferrer noopener">Video showcase</a> by TrophyTom</> }
+          </span>
         </div>
       </Popup>
     </Marker>

--- a/src/data/lockedDoors.js
+++ b/src/data/lockedDoors.js
@@ -83,4 +83,10 @@ export const lockedDoors = {
     position: [53.54, 112.36],
     image: "Plort/iconPlortPink.png",
   },
+  "locked_43": {
+    name: "Angler Door Receptacle",
+    amount: 1,
+    position: [74.1, 71.0],
+    image: "Plort/iconPlortAngler.png",
+  },
 }

--- a/src/data/lockedDoors.js
+++ b/src/data/lockedDoors.js
@@ -86,7 +86,13 @@ export const lockedDoors = {
   "locked_43": {
     name: "Angler Door Receptacle",
     amount: 1,
-    position: [74.1, 71.0],
+    position: [74.1, 71],
     image: "Plort/iconPlortAngler.png",
+  },
+  "locked_73": {
+    name: "Flutter Door Receptacle",
+    amount: 1,
+    position: [39.6, 108],
+    image: "Plort/iconPlortFlutter.png",
   },
 }

--- a/src/data/treasurePods.js
+++ b/src/data/treasurePods.js
@@ -19,7 +19,7 @@ export const treasurePods = {
   "treasure_3": {
     name: "Treasure Pod 3",
     contents: "Veggie Flag",
-    description: "Located outside the tunnel of The Den expansion. Jetpack across under the arched rock, treasure pod is on a ledge across to the left.",
+    description: "Located on the other side of The Den expansion. Jetpack across under the arched rock, treasure pod is on a ledge across to the left.",
     embedded: "https://youtu.be/_FU8PIxIdOc?t=90",
     required: "Jetpack",
     position: [68.25, 156.3]
@@ -157,7 +157,7 @@ export const treasurePods = {
   "treasure_21": {
     name: "Treasure Pod 4",
     contents: "Cinder Spike Blossoms",
-    description: "On a small ledge off thd cliff-side.",
+    description: "On a small ledge off the cliff-side.",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=161",
     position: [81.35, 70.4]
   },
@@ -314,124 +314,154 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=781",
     position: [74.22, 44.2]
   },
+  "treasure_42": {
+    name: "Treasure Pod 25",
+    contents: "Stony Egg Lamp",
+    description: "Inside a stone pillar, above the cave entrance. A Cuberry tree is also inside.",
+    required: "Jetpack",
+    embedded: "https://youtu.be/DeT1csKLrck?t=306",
+    position: [77.77, 77.4]
+  },
+  "treasure_43": {
+    name: "Treasure Pod 26",
+    contents: "Sureshot Module",
+    description: "Inside, located behind the locked door. An angler plort receptor under the bridge unlocks the door.",
+    required: "Jetpack",
+    embedded: "https://youtu.be/DeT1csKLrck?t=332",
+    position: [74.25, 73.3]
+  },
+  "treasure_44": {
+    name: "Treasure Pod 27",
+    contents: "Golden Angler Statue",
+    description: "Behind the waterfall.",
+    embedded: "https://youtu.be/DeT1csKLrck?t=398",
+    position: [80.35, 49.4]
+  },
+  "treasure_45": {
+    name: "Treasure Pod 28",
+    contents: "Golden Chicken Statue",
+    description: "On grass above the ruins near the Powderfall Bluffs teleporter.",
+    embedded: "https://youtu.be/DeT1csKLrck?t=436",
+    position: [73.72, 51.2]
+  },
 
   // Starlight Strand
-  "treasure_42": {
+  "treasure_46": {
     name: "Treasure Pod 1",
     contents: "Cheerful Statue",
     position: [63.27, 98.30]
   },
-  "treasure_43": {
+  "treasure_47": {
     name: "Treasure Pod 2",
     contents: "Rock Cluster",
     position: [65.05, 86.83]
   },
-  "treasure_44": {
+  "treasure_48": {
     name: "Treasure Pod 3",
     contents: "Stalagmite Cluster",
     position: [67.75, 98.92]
   },
-  "treasure_45": {
+  "treasure_49": {
     name: "Treasure Pod 4",
     contents: "Coastal Rock Pillar",
     position: [65.13, 107.6]
   },
-  "treasure_46": {
+  "treasure_50": {
     name: "Treasure Pod 5",
     contents: "Tank Liner",
     position: [60.35, 119.6]
   },
-  "treasure_47": {
+  "treasure_51": {
     name: "Treasure Pod 6",
     contents: "Veggie Slime Bait",
     position: [61.3, 120.5]
   },
-  "treasure_48": {
+  "treasure_52": {
     name: "Treasure Pod 7",
     contents: "Tall Pink Coral Columns",
     position: [59.31, 122.69]
   },
-  "treasure_49": {
+  "treasure_53": {
     name: "Treasure Pod 8",
     contents: "Storage Cell",
     position: [58.3, 109.99]
   },
-  "treasure_50": {
+  "treasure_54": {
     name: "Treasure Pod 9",
     contents: "Sharp Boulder",
     position: [56.55, 121.81]
   },
-  "treasure_51": {
+  "treasure_55": {
     name: "Treasure Pod 10",
     contents: "Violet Warp Depot",
     position: [57.49, 111.26]
   },
-  "treasure_52": {
+  "treasure_56": {
     name: "Treasure Pod 11",
     contents: "Dash Boot Module",
     position: [51.83, 114.43]
   },
-  "treasure_53": {
+  "treasure_57": {
     name: "Treasure Pod 12",
     contents: "Root Tangle",
     position: [53.3, 116.58]
   },
-  "treasure_54": {
+  "treasure_58": {
     name: "Treasure Pod 13",
     contents: "Cave Pillar",
     position: [55, 124]
   },
-  "treasure_55": {
+  "treasure_59": {
     name: "Treasure Pod 14",
     contents: "Pink Glow Shrooms",
     position: [43.45, 131.3]
   },
-  "treasure_56": {
+  "treasure_60": {
     name: "Treasure Pod 15",
     contents: "Tank Liner",
     position: [43.51, 137.24]
   },
-  "treasure_57": {
+  "treasure_61": {
     name: "Treasure Pod 16",
     contents: "Spring Pad",
     position: [39.57, 125.06]
   },
-  "treasure_58": {
+  "treasure_62": {
     name: "Treasure Pod 17",
     contents: "Starbloom Flowers",
     position: [45.24, 118.74]
   },
-  "treasure_59": {
+  "treasure_63": {
     name: "Treasure Pod 18",
     contents: "Starlight Strand Portal",
     position: [40.31, 116.54]
   },
-  "treasure_60": {
+  "treasure_64": {
     name: "Treasure Pod 19",
     contents: "Power Chip",
     position: [37.3, 95.58]
   },
-  "treasure_61": {
+  "treasure_65": {
     name: "Treasure Pod 20",
     contents: "Tall Violet Swirl Shroom",
     position: [44.55, 107.57]
   },
-  "treasure_62": {
+  "treasure_66": {
     name: "Treasure Pod 21",
     contents: "Azure Shrubs",
     position: [50.56, 104.23]
   },
-  "treasure_63": {
+  "treasure_67": {
     name: "Treasure Pod 22",
     contents: "Azure Mangrove",
     position: [45.42, 112.67]
   },
-  "treasure_64": {
+  "treasure_68": {
     name: "Treasure Pod 23",
     contents: "Novice Gordo Snare",
     position: [50.03, 103.71]
   },
-  "treasure_65": {
+  "treasure_69": {
     name: "Treasure Pod 24",
     contents: "Azure Grass",
     position: [54.92, 98.74]

--- a/src/data/treasurePods.js
+++ b/src/data/treasurePods.js
@@ -466,4 +466,35 @@ export const treasurePods = {
     contents: "Azure Grass",
     position: [54.92, 98.74]
   },
+  "treasure_70": {
+    name: "Treasure Pod 25",
+    contents: "Mossy Hen Statue",
+    description: "Above the rock arch, and around the back of the outer rock.",
+    required: "Jetpack",
+    embedded: "https://youtu.be/DeT1csKLrck?t=143",
+    position: [58.9, 130.73]
+  },
+  "treasure_71": {
+    name: "Treasure Pod 26",
+    contents: "Golden Flutter Statue",
+    description: "Among the tree roots in a puddle",
+    embedded: "https://youtu.be/DeT1csKLrck?t=183",
+    position: [49.12, 125.3]
+  },
+  "treasure_72": {
+    name: "Treasure Pod 27",
+    contents: "Golden Cotton Statue",
+    description: "Inside the curved ruins, on a recessed shelf facing the sea",
+    required: "Jetpack",
+    embedded: "https://youtu.be/DeT1csKLrck?t=214",
+    position: [47.32, 102.3]
+  },
+  "treasure_73": {
+    name: "Treasure Pod 28",
+    contents: "Sureshot Module",
+    description: "Inside the ruins behind a door unlocked with a Flutter Plort.",
+    required: "Jetpack",
+    embedded: "https://youtu.be/DeT1csKLrck?t=249",
+    position: [39.6, 109.2]
+  },
 }

--- a/src/data/treasurePods.js
+++ b/src/data/treasurePods.js
@@ -4,21 +4,21 @@ export const treasurePods = {
     name: "Treasure Pod 1",
     contents: "Tank Liner",
     description: "Burst the Gordo first, then shoot a tabby plort inside the statue.",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=7",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=7",
     position: [74.95, 126.3]
   },
   "treasure_2": {
     name: "Treasure Pod 2",
     contents: "Hydro Turret",
     description: "N/A",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=39",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=39",
     position: [77.37, 123]
   },
   "treasure_3": {
     name: "Treasure Pod 3",
     contents: "Gold Petal Flowers",
     description: "Jetpack into the cave, go through to the end, treasure pod is on a ledge to the left.",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=67",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=67",
     required: "Jetpack",
     position: [78.35, 119.6]
   },
@@ -26,14 +26,14 @@ export const treasurePods = {
     name: "Treasure Pod 4",
     contents: "Heart Cell",
     description: "Hidden inside a hole in the wall.",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=100",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=100",
     position: [76.1, 121.7]
   },
   "treasure_5": {
     name: "Treasure Pod 5",
     contents: "Small Boulder",
     description: "",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=130",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=130",
     required: "Jetpack",
     position: [76.35, 118]
   },
@@ -41,14 +41,14 @@ export const treasurePods = {
     name: "Treasure Pod 6",
     contents: "Large Pink Bonsai",
     description: "N/A",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=169",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=169",
     position: [73.8, 117.1]
   },
   "treasure_7": {
     name: "Treasure Pod 7",
     contents: "#1 Slime Stage",
     description: "Use the trees near the cliff to parkour/jetpack your way up.",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=196",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=196",
     required: "Jetpack",
     position: [73.45, 116.9]
   },
@@ -56,7 +56,7 @@ export const treasurePods = {
     name: "Treasure Pod 8",
     contents: "Rock Fragments",
     description: "Jetpack over to the external islands. The treasure pod is behind the rock pillar.",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=288",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=288",
     required: "Jetpack",
     position: [69.7, 128.5]
   },
@@ -64,35 +64,35 @@ export const treasurePods = {
     name: "Treasure Pod 9",
     contents: "Pink Warp Depot",
     description: "Found underground by accessing a crack in the wall near the ocean level.",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=245",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=245",
     position: [70.8, 128.5]
   },
   "treasure_10": {
     name: "Treasure Pod 10",
     contents: "Power Chip",
     description: "Found underground by accessing a crack in the wall near the ocean level.",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=315",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=315",
     position: [72.35, 111.5],
   },
   "treasure_11": {
     name: "Treasure Pod 11",
     contents: "Med Station",
     description: "Behind the teleporter, hidden inside a hole in the wall.",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=342",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=342",
     position: [70.91, 103.8]
   },
   "treasure_12": {
     name: "Treasure Pod 12",
     contents: "Emerald Cypress",
     description: "hidden inside a cave",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=367",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=367",
     position: [73.9, 105.8]
   },
   "treasure_13": {
     name: "Treasure Pod 13",
     contents: "Overjoyed Statue",
     description: "N/A",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=392",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=392",
     required: "Jetpack",
     position: [74.85, 111.9]
   },
@@ -100,7 +100,7 @@ export const treasurePods = {
     name: "Treasure Pod 14",
     contents: "Emerald Cypress Cluster",
     description: "N/A",
-    embedd: "https://youtu.be/2pKPJgag8QA?t=421",
+    embedded: "https://youtu.be/2pKPJgag8QA?t=421",
     position: [76.1, 99]
   },
   

--- a/src/data/treasurePods.js
+++ b/src/data/treasurePods.js
@@ -1,20 +1,46 @@
 export const treasurePods = {
-  // Rainbow Fields
+  // The Conservatory
   "treasure_1": {
+    name: "Treasure Pod 1",
+    contents: "Meat Flag",
+    description: "Located inside The Gully expansion. Find the small ledges on the mountain and climb up.",
+    embedded: "https://youtu.be/_FU8PIxIdOc?t=7",
+    required: "Jetpack",
+    position: [77.8, 141.8]
+  },
+  "treasure_2": {
+    name: "Treasure Pod 2",
+    contents: "Fruit Flag",
+    description: "Located through The Archway expansion. Jetpack to the island to the East, and look on top of the tree directly above the Research Drone.",
+    required: "Jetpack",
+    embedded: "https://youtu.be/_FU8PIxIdOc?t=53",
+    position: [73.45, 172.08]
+  },
+  "treasure_3": {
+    name: "Treasure Pod 3",
+    contents: "Veggie Flag",
+    description: "Located outside the tunnel of The Den expansion. Jetpack across under the arched rock, treasure pod is on a ledge across to the left.",
+    embedded: "https://youtu.be/_FU8PIxIdOc?t=90",
+    required: "Jetpack",
+    position: [68.25, 156.3]
+  },
+
+  // Rainbow Fields
+  "treasure_4": {
     name: "Treasure Pod 1",
     contents: "Tank Liner",
     description: "Burst the Gordo first, then shoot a tabby plort inside the statue.",
     embedded: "https://youtu.be/2pKPJgag8QA?t=7",
     position: [74.95, 126.3]
   },
-  "treasure_2": {
+  "treasure_5": {
     name: "Treasure Pod 2",
     contents: "Hydro Turret",
     description: "N/A",
     embedded: "https://youtu.be/2pKPJgag8QA?t=39",
     position: [77.37, 123]
   },
-  "treasure_3": {
+  "treasure_6": {
     name: "Treasure Pod 3",
     contents: "Gold Petal Flowers",
     description: "Jetpack into the cave, go through to the end, treasure pod is on a ledge to the left.",
@@ -22,14 +48,14 @@ export const treasurePods = {
     required: "Jetpack",
     position: [78.35, 119.6]
   },
-  "treasure_4": {
+  "treasure_7": {
     name: "Treasure Pod 4",
     contents: "Heart Cell",
     description: "Hidden inside a hole in the wall.",
     embedded: "https://youtu.be/2pKPJgag8QA?t=100",
     position: [76.1, 121.7]
   },
-  "treasure_5": {
+  "treasure_8": {
     name: "Treasure Pod 5",
     contents: "Small Boulder",
     description: "",
@@ -37,14 +63,14 @@ export const treasurePods = {
     required: "Jetpack",
     position: [76.35, 118]
   },
-  "treasure_6": {
+  "treasure_9": {
     name: "Treasure Pod 6",
     contents: "Large Pink Bonsai",
     description: "N/A",
     embedded: "https://youtu.be/2pKPJgag8QA?t=169",
     position: [73.8, 117.1]
   },
-  "treasure_7": {
+  "treasure_10": {
     name: "Treasure Pod 7",
     contents: "#1 Slime Stage",
     description: "Use the trees near the cliff to parkour/jetpack your way up.",
@@ -52,7 +78,7 @@ export const treasurePods = {
     required: "Jetpack",
     position: [73.45, 116.9]
   },
-  "treasure_8": {
+  "treasure_11": {
     name: "Treasure Pod 8",
     contents: "Rock Fragments",
     description: "Jetpack over to the external islands. The treasure pod is behind the rock pillar.",
@@ -60,35 +86,35 @@ export const treasurePods = {
     required: "Jetpack",
     position: [69.7, 128.5]
   },
-  "treasure_9": {
+  "treasure_12": {
     name: "Treasure Pod 9",
     contents: "Pink Warp Depot",
     description: "Found underground by accessing a crack in the wall near the ocean level.",
     embedded: "https://youtu.be/2pKPJgag8QA?t=245",
     position: [70.8, 128.5]
   },
-  "treasure_10": {
+  "treasure_13": {
     name: "Treasure Pod 10",
     contents: "Power Chip",
     description: "Found underground by accessing a crack in the wall near the ocean level.",
     embedded: "https://youtu.be/2pKPJgag8QA?t=315",
     position: [72.35, 111.5],
   },
-  "treasure_11": {
+  "treasure_14": {
     name: "Treasure Pod 11",
     contents: "Med Station",
     description: "Behind the teleporter, hidden inside a hole in the wall.",
     embedded: "https://youtu.be/2pKPJgag8QA?t=342",
     position: [70.91, 103.8]
   },
-  "treasure_12": {
+  "treasure_15": {
     name: "Treasure Pod 12",
     contents: "Emerald Cypress",
     description: "hidden inside a cave",
     embedded: "https://youtu.be/2pKPJgag8QA?t=367",
     position: [73.9, 105.8]
   },
-  "treasure_13": {
+  "treasure_16": {
     name: "Treasure Pod 13",
     contents: "Overjoyed Statue",
     description: "N/A",
@@ -96,23 +122,23 @@ export const treasurePods = {
     required: "Jetpack",
     position: [74.85, 111.9]
   },
-  "treasure_14": {
+  "treasure_17": {
     name: "Treasure Pod 14",
     contents: "Emerald Cypress Cluster",
     description: "N/A",
     embedded: "https://youtu.be/2pKPJgag8QA?t=421",
     position: [76.1, 99]
   },
-  
+
   // Ember Valley
-  "treasure_15": {
+  "treasure_18": {
     name: "Treasure Pod 1",
     contents: "Storage Cell",
     description: "Shoot a Batty plort at the statue to open the door.",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=7",
     position: [77, 84.5]
   },
-  "treasure_16": {
+  "treasure_19": {
     name: "Treasure Pod 2",
     contents: "Azure Glow Shrooms",
     description: "Shoot 3 Boom plorts at the statues to open the door.",
@@ -121,21 +147,21 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=40",
     position: [78.6, 75.5]
   },
-  "treasure_17": {
+  "treasure_20": {
     name: "Treasure Pod 3",
     contents: "Jetpack Drive",
     description: "Burst the Gordo first.",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=122",
     position: [79.35, 69.8]
   },
-  "treasure_18": {
+  "treasure_21": {
     name: "Treasure Pod 4",
     contents: "Cinder Spike Blossoms",
     description: "On a small ledge off thd cliff-side.",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=161",
     position: [81.35, 70.4]
   },
-  "treasure_19": {
+  "treasure_22": {
     name: "Treasure Pod 5",
     contents: "Sunfire Daisies",
     description: "N/A",
@@ -143,14 +169,14 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=182",
     position: [81.25, 58.5]
   },
-  "treasure_20": {
+  "treasure_23": {
     name: "Treasure Pod 6",
     contents: "Heart Cell",
     description: "On a ledge off the side of the island, hidden inside a small hole in the wall.",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=220",
     position: [79.75, 54.4]
   },
-  "treasure_21": {
+  "treasure_24": {
     name: "Treasure Pod 7",
     contents: "Blue Warp Depot",
     description: "Follow the path down the side of the island, the treasure pod will be in a small chamber.",
@@ -158,14 +184,14 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=247",
     position: [82.3, 52.3]
   },
-  "treasure_22": {
+  "treasure_25": {
     name: "Treasure Pod 8",
     contents: "Amber Cypress",
     description: "N/A",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=297",
     position: [78.72, 56.78]
   },
-  "treasure_23": {
+  "treasure_26": {
     name: "Treasure Pod 9",
     contents: "Happy Statue",
     description: "Reached by jumping onto a small ledge off the island and flying towards the small cave.",
@@ -173,7 +199,7 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=317",
     position: [80.1, 56.4]
   },
-  "treasure_24": {
+  "treasure_27": {
     name: "Treasure Pod 10",
     contents: "Amber Cypress Cluster",
     description: "N/A",
@@ -181,7 +207,7 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=345",
     position: [78, 56.96]
   },
-  "treasure_25": {
+  "treasure_28": {
     name: "Treasure Pod 11",
     contents: "Dash Pad",
     description: "Inside one of the stone pillars.",
@@ -189,7 +215,7 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=386",
     position: [77.45, 63.63]
   },
-  "treasure_26": {
+  "treasure_29": {
     name: "Treasure Pod 12",
     contents: "Meat Slime Bait",
     description: "Inside one of the stone pillars.",
@@ -197,7 +223,7 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=409",
     position: [77.08, 70.8]
   },
-  "treasure_27": {
+  "treasure_30": {
     name: "Treasure Pod 13",
     contents: "Medium Pink Coral Columns",
     description: "N/A",
@@ -205,7 +231,7 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=443",
     position: [76.1, 62]
   },
-  "treasure_28": {
+  "treasure_31": {
     name: "Treasure Pod 14",
     contents: "Gnarled Ashwood",
     description: "Hidden in a hole in the island wall. Jump onto the small platform beside the island to get there.",
@@ -213,7 +239,7 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=470",
     position: [75.4, 58]
   },
-  "treasure_29": {
+  "treasure_32": {
     name: "Treasure Pod 15",
     contents: "VAC Tank",
     description: "Go through the waterfall and follow the cave to it's exit near the top. Outside is a small pond with the treasure pod inside.",
@@ -221,14 +247,14 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=493",
     position: [76.36, 56.85]
   },
-  "treasure_30": {
+  "treasure_33": {
     name: "Treasure Pod 16",
     contents: "Stalagmite",
     description: "In a large cave accessed by a hole in the wall. Follow the path and the treasure pod will be on a small platform off the side of a stone pillar.",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=543",
     position: [75.4, 49.8]
   },
-  "treasure_31": {
+  "treasure_34": {
     name: "Treasure Pod 17",
     contents: "Grey Warp Depot",
     description: "In the top lava pool platform.",
@@ -236,7 +262,7 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=578",
     position: [77.95, 47.7]
   },
-  "treasure_32": {
+  "treasure_35": {
     name: "Treasure Pod 18",
     contents: "Fruit Slime Bait",
     description: "In a small cave accessed by a hole in the wall covered with vines.",
@@ -244,7 +270,7 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=624",
     position: [78.41, 40.6]
   },
-  "treasure_33": {
+  "treasure_36": {
     name: "Treasure Pod 19",
     contents: "Medium Palm",
     description: "Sitting on a ledge off the side of a stone pillar.",
@@ -252,28 +278,28 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=654",
     position: [77.51, 36]
   },
-  "treasure_34": {
+  "treasure_37": {
     name: "Treasure Pod 20",
     contents: "Ember Valley Portal",
     description: "Burst the Gordo first.",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=685",
     position: [77.74, 26.6]
   },
-  "treasure_35": {
+  "treasure_38": {
     name: "Treasure Pod 21",
     contents: "Ember Valley Portal",
     description: "Burst the Gordo first.",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=685",
     position: [77.8, 26.4]
   },
-  "treasure_36": {
+  "treasure_39": {
     name: "Treasure Pod 22",
     contents: "Tall Magma Clump",
     description: "Sitting on a ledge off the side of a stone pillar.",
     embedded: "https://youtu.be/7mpFRKyEcxs?t=733",
     position: [76.05, 38]
   },
-  "treasure_37": {
+  "treasure_40": {
     name: "Treasure Pod 23",
     contents: "Magma Pool",
     description: "On a small ledge found at the bottom near lava river next to the lavafall.",
@@ -281,7 +307,7 @@ export const treasurePods = {
     embedded: "https://youtu.be/7mpFRKyEcxs?t=757",
     position: [74.95, 42]
   },
-  "treasure_38": {
+  "treasure_41": {
     name: "Treasure Pod 24",
     contents: "Medium Red Ashwood",
     description: "N/A",
@@ -290,122 +316,122 @@ export const treasurePods = {
   },
 
   // Starlight Strand
-  "treasure_39": {
+  "treasure_42": {
     name: "Treasure Pod 1",
     contents: "Cheerful Statue",
     position: [63.27, 98.30]
   },
-  "treasure_40": {
+  "treasure_43": {
     name: "Treasure Pod 2",
     contents: "Rock Cluster",
     position: [65.05, 86.83]
   },
-  "treasure_41": {
+  "treasure_44": {
     name: "Treasure Pod 3",
     contents: "Stalagmite Cluster",
     position: [67.75, 98.92]
   },
-  "treasure_42": {
+  "treasure_45": {
     name: "Treasure Pod 4",
     contents: "Coastal Rock Pillar",
     position: [65.13, 107.6]
   },
-  "treasure_43": {
+  "treasure_46": {
     name: "Treasure Pod 5",
     contents: "Tank Liner",
     position: [60.35, 119.6]
   },
-  "treasure_44": {
+  "treasure_47": {
     name: "Treasure Pod 6",
     contents: "Veggie Slime Bait",
     position: [61.3, 120.5]
   },
-  "treasure_45": {
+  "treasure_48": {
     name: "Treasure Pod 7",
     contents: "Tall Pink Coral Columns",
     position: [59.31, 122.69]
   },
-  "treasure_46": {
+  "treasure_49": {
     name: "Treasure Pod 8",
     contents: "Storage Cell",
     position: [58.3, 109.99]
   },
-  "treasure_47": {
+  "treasure_50": {
     name: "Treasure Pod 9",
     contents: "Sharp Boulder",
     position: [56.55, 121.81]
   },
-  "treasure_48": {
+  "treasure_51": {
     name: "Treasure Pod 10",
     contents: "Violet Warp Depot",
     position: [57.49, 111.26]
   },
-  "treasure_49": {
+  "treasure_52": {
     name: "Treasure Pod 11",
     contents: "Dash Boot Module",
     position: [51.83, 114.43]
   },
-  "treasure_50": {
+  "treasure_53": {
     name: "Treasure Pod 12",
     contents: "Root Tangle",
     position: [53.3, 116.58]
   },
-  "treasure_51": {
+  "treasure_54": {
     name: "Treasure Pod 13",
     contents: "Cave Pillar",
     position: [55, 124]
   },
-  "treasure_52": {
+  "treasure_55": {
     name: "Treasure Pod 14",
     contents: "Pink Glow Shrooms",
     position: [43.45, 131.3]
   },
-  "treasure_53": {
+  "treasure_56": {
     name: "Treasure Pod 15",
     contents: "Tank Liner",
     position: [43.51, 137.24]
   },
-  "treasure_54": {
+  "treasure_57": {
     name: "Treasure Pod 16",
     contents: "Spring Pad",
     position: [39.57, 125.06]
   },
-  "treasure_55": {
+  "treasure_58": {
     name: "Treasure Pod 17",
     contents: "Starbloom Flowers",
     position: [45.24, 118.74]
   },
-  "treasure_56": {
+  "treasure_59": {
     name: "Treasure Pod 18",
     contents: "Starlight Strand Portal",
     position: [40.31, 116.54]
   },
-  "treasure_57": {
+  "treasure_60": {
     name: "Treasure Pod 19",
     contents: "Power Chip",
     position: [37.3, 95.58]
   },
-  "treasure_58": {
+  "treasure_61": {
     name: "Treasure Pod 20",
     contents: "Tall Violet Swirl Shroom",
     position: [44.55, 107.57]
   },
-  "treasure_59": {
+  "treasure_62": {
     name: "Treasure Pod 21",
     contents: "Azure Shrubs",
     position: [50.56, 104.23]
   },
-  "treasure_60": {
+  "treasure_63": {
     name: "Treasure Pod 22",
     contents: "Azure Mangrove",
     position: [45.42, 112.67]
   },
-  "treasure_61": {
+  "treasure_64": {
     name: "Treasure Pod 23",
     contents: "Novice Gordo Snare",
     position: [50.03, 103.71]
   },
-  "treasure_62": {
+  "treasure_65": {
     name: "Treasure Pod 24",
     contents: "Azure Grass",
     position: [54.92, 98.74]


### PR DESCRIPTION
Thanks to all, this is a useful map. I found I could help so I added the 11 missing treasure pods due to the 0.2.0 update (not including Powderfall Bluffs). Also added 2 plort door markers as two pods were locked behind them.

This does not include any from Powderfall Bluffs. I did see the new map asset in the assets, so I could try rescaling the icons coordinates to that one next. But I wanted to go ahead and propose these changes.
