### PR TITLE
adding four missing user pin options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,7 @@ function App() {
                 icon={icon}
             >
                 <Popup>
-                    <button onClick={handleClick}>Remove</button>
+                    <button className="border w-[5rem] mt-2 self-end" onClick={handleClick}>Remove</button>
                 </Popup>
             </Marker>
         );

--- a/src/data/pins.ts
+++ b/src/data/pins.ts
@@ -85,13 +85,17 @@ const resources = [
     "JellyStone",
     "LavaDust",
     "PepperJam",
+    "PerfectSnowflake",
     "PrimordyOil",
     "RadiantOre",
+    "RoyalJelly",
     "SilkySand",
     "SlimeFossil",
+    "Snowball",
     "SpiralSteam",
     "StrangeDiamond",
     "WildHoney",
+    "SunSap",
 ];
 
 export const pins: { [key: string]: Pin } = {


### PR DESCRIPTION
Added the missing icons for user pins: Perfect Snowflake, Snowball, Sun Sap, and Royal Jelly.

Also added border style to the user pin popup's "Remove" button. Now it looks like the research drone popup's "Access Log" button. Feels more consistent -- and makes the Remove button actually look like a button. (On two separate occasions I have wondered why clicking the 'x' in the top right of the popup wasn't removing the user pin ... it's because I had not realized the "Remove" text was actually a button.)