### PR TITLE
fix 1st option being shown as empty

### DIFF
--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -105,7 +105,7 @@ export default function Planner({
                                 <select
                                     onChange={(e) => onChange(parseInt(e.target.value, 10), Side.left, plotType?.optionsA ?? [])}
                                     className="bg-blue-900 outline outline-1 p-1"
-                                    value={plotPlan.selectedOptionA ? plotPlan.selectedOptionA : "Empty"}
+                                    value={plotPlan.selectedOptionA !== undefined ? plotPlan.selectedOptionA : "Empty"}
                                 >
                                     <option>Empty</option>
                                     {plotType.optionsA.map((resource, index) => (
@@ -144,7 +144,7 @@ export default function Planner({
                                 <select
                                     onChange={(e) => onChange(parseInt(e.target.value, 10), Side.right, plotType?.optionsB ?? [])}
                                     className="bg-blue-900 outline outline-1 p-1"
-                                    value={plotPlan.selectedOptionB ? plotPlan.selectedOptionB : "Empty"}
+                                    value={plotPlan.selectedOptionB !== undefined ? plotPlan.selectedOptionB : "Empty"}
                                 >
                                     <option>Empty</option>
                                     {plotType.optionsB.map((resource, index) => (


### PR DESCRIPTION
## Description

The 1st option was shown as empty. When a number is zero, the ternary operator jumps into the else block. Fixed that.

Fixes #31 

## Screenshot

<img width="321" alt="image" src="https://github.com/user-attachments/assets/45a822f0-3426-4f4d-ba97-84d602c2ee45" />
