### PR TITLE
fix: unselecting yolky slime on coop also unrenders meat

### DIFF
--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -55,7 +55,7 @@ export default function Planner({
                         ? icons.left !== null && icons.left.icon.options.iconUrl.includes("plots")
                             ? null
                             : icons.left
-                        : {
+                        : icons.left !== undefined ? icons.left : {
                             name: plotType?.name ?? "",
                             icon: L.icon({
                                 ...icon_template,

--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -55,7 +55,7 @@ export default function Planner({
                         ? icons.left !== null && icons.left.icon.options.iconUrl.includes("plots")
                             ? null
                             : icons.left
-                        : icons.left !== undefined ? icons.left : {
+                        : icons.left !== null ? icons.left : {
                             name: plotType?.name ?? "",
                             icon: L.icon({
                                 ...icon_template,


### PR DESCRIPTION
## Description
For coop, when a meat and yolky were selected, and then yolky was unselected, the meat was unrendered. Fixing that by adding a check for whether the left icon is set before overwriting the left icon with the coop icon.

Fixes #39 

## Screenshots

<img width="341" alt="Screenshot 2024-12-22 at 8 22 39 PM" src="https://github.com/user-attachments/assets/82e8bed2-de5a-4400-9bde-4de9fcaac5b1" />


Screenshot immediately after deselecting yolky: 
<img width="341" alt="Screenshot 2024-12-22 at 8 22 42 PM" src="https://github.com/user-attachments/assets/a8580c0d-91cc-4cb8-af76-f1b25141c867" />
