### PR TITLE
feat: import / export / clear pins

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,10 @@ function App() {
                 {current_log}
             </div>
 
-            <Sidebar selected_pin={selected_pin} setSelectedPin={setSelectedPin} />
+            <Sidebar 
+                selected_pin={selected_pin} setSelectedPin={setSelectedPin} 
+                user_pins={user_pins} setUserPins={setUserPins} 
+            />
 
             <MapContainer
                 // TODO: Ideally, we'd have this centered 0,0 and have the tilemap centered as well.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -55,12 +55,6 @@ export default function Sidebar({
 
                     <hr />
 
-                    <ExportUserPinsButton />
-                    <ImportUserPinsButton setUserPins={setUserPins} />
-                    <ClearUserPinsButton setUserPins={setUserPins} />
-
-                    <hr />
-
                     <div>
                         <div className="flex flex-col md:flex-row gap-2 md:gap-0 justify-between mb-1 md:items-center">
                             <h2 className="text-lg font-bold">Plot Planner</h2>
@@ -68,6 +62,14 @@ export default function Sidebar({
                         <div className="flex flex-wrap md:items-center">
                             <h2>You can click on any plot on the map to start planning!</h2>
                         </div>
+                    </div>
+
+                    <hr />
+
+                    <div className="flex flex-col md:flex-row justify-between gap-4 lg:gap-6 mb-4">
+                        <ExportUserPinsButton />
+                        <ImportUserPinsButton setUserPins={setUserPins} />
+                        <ClearUserPinsButton setUserPins={setUserPins} />
                     </div>
                 </div>
             </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,18 +1,20 @@
 import { AiFillDiscord, AiFillGithub } from "react-icons/ai";
+import { ClearUserPinsButton, ExportUserPinsButton, ImportUserPinsButton, SidebarPins } from "./UserPins";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
+import { LocalStoragePin, Pin } from "../types";
 import React, { useState } from "react";
 import { discord_link, github_link } from "../globals";
 import CollectablesTracker from "./CollectablesTracker";
 import IslandInfo from "./IslandInfo";
-import { Pin } from "../types";
-import { SidebarPins } from "./UserPins";
 
 export default function Sidebar({
     selected_pin,
     setSelectedPin,
+    setUserPins,
 }: {
     selected_pin: Pin | undefined,
     setSelectedPin: React.Dispatch<React.SetStateAction<Pin | undefined>>
+    setUserPins: React.Dispatch<React.SetStateAction<LocalStoragePin[]>>
 }) {
     const [show_sidebar, setShowSidebar] = useState(false);
 
@@ -50,6 +52,12 @@ export default function Sidebar({
                     <hr />
 
                     <IslandInfo />
+
+                    <hr />
+
+                    <ExportUserPinsButton />
+                    <ImportUserPinsButton setUserPins={setUserPins} />
+                    <ClearUserPinsButton setUserPins={setUserPins} />
 
                     <hr />
 

--- a/src/components/UserPins.tsx
+++ b/src/components/UserPins.tsx
@@ -133,14 +133,14 @@ export function ExportUserPinsButton() {
     const pins_json_file = new Blob([pins_json], { type: "application/json" });
 
     return (
-        <button>
+        <button className="bg-blue-900 w-full outline outline-1 p-1">
             <a
                 download="user_pins.json"
                 target="_blank"
                 rel="noreferrer"
                 href={URL.createObjectURL(pins_json_file)}
             >
-                Export pins
+                Export Pins
             </a>
         </button>
     );
@@ -152,22 +152,27 @@ export function ImportUserPinsButton({
     setUserPins: React.Dispatch<React.SetStateAction<LocalStoragePin[]>>
 }) {
     return (
-        <label htmlFor="upload" className="cursor-pointer">
-            <span>Import pins</span>
+        <label
+            htmlFor="upload"
+            className="flex justify-center items-center w-full cursor-pointer bg-blue-900 outline outline-1 p-1 text-center"
+        >
+            <span>Import Pins</span>
             <input
                 type="file"
                 accept=".json"
                 id="upload"
                 className="hidden"
                 onChange={(event) => {
-                    const file = event.target.files[0];
+                    const file = (event.target.files ?? [])[0];
                     if (!file) return;
 
                     const reader = new FileReader();
                     reader.onload = (e) => {
-                        const pins_json = e.target?.result;
-                        localStorage.setItem("user_pins", pins_json);
-                        setUserPins(JSON.parse(pins_json));
+                        const pins_json = e.target?.result as string;
+                        if (window.confirm("This will overwrite your current pins. Are you sure you want to continue?")) {
+                            localStorage.setItem("user_pins", pins_json);
+                            setUserPins(JSON.parse(pins_json));
+                        }
                     };
                     reader.onerror = () => {
                         console.error("error: failed to read user pins");
@@ -186,11 +191,13 @@ export function ClearUserPinsButton({
     setUserPins: React.Dispatch<React.SetStateAction<LocalStoragePin[]>>
 }) {
     return (
-        <button onClick={() => {
-            setUserPins([]);
-            localStorage.setItem("user_pins", JSON.stringify([]));
-        }}>
-            Clear pins
+        <button
+            className="bg-red-600 p-1 w-full outline outline-1"
+            onClick={() => {
+                setUserPins([]);
+                localStorage.setItem("user_pins", JSON.stringify([]));
+            }}>
+            Clear Pins
         </button>
     );
 }

--- a/src/components/UserPins.tsx
+++ b/src/components/UserPins.tsx
@@ -127,3 +127,70 @@ export function MapUserPins({
 
     return null;
 }
+
+export function ExportUserPinsButton() {
+    const pins_json = localStorage.getItem("user_pins") ?? "";
+    const pins_json_file = new Blob([pins_json], { type: "application/json" });
+
+    return (
+        <button>
+            <a
+                download="user_pins.json"
+                target="_blank"
+                rel="noreferrer"
+                href={URL.createObjectURL(pins_json_file)}
+            >
+                Export pins
+            </a>
+        </button>
+    );
+}
+
+export function ImportUserPinsButton({
+    setUserPins
+}: {
+    setUserPins: React.Dispatch<React.SetStateAction<LocalStoragePin[]>>
+}) {
+    return (
+        <label htmlFor="upload" className="cursor-pointer">
+            <span>Import pins</span>
+            <input
+                type="file"
+                accept=".json"
+                id="upload"
+                className="hidden"
+                onChange={(event) => {
+                    const file = event.target.files[0];
+                    if (!file) return;
+
+                    const reader = new FileReader();
+                    reader.onload = (e) => {
+                        const pins_json = e.target?.result;
+                        localStorage.setItem("user_pins", pins_json);
+                        setUserPins(JSON.parse(pins_json));
+                    };
+                    reader.onerror = () => {
+                        console.error("error: failed to read user pins");
+                    };
+
+                    reader.readAsText(file);
+                }}
+            />
+        </label>
+    );
+}
+
+export function ClearUserPinsButton({
+    setUserPins
+}: {
+    setUserPins: React.Dispatch<React.SetStateAction<LocalStoragePin[]>>
+}) {
+    return (
+        <button onClick={() => {
+            setUserPins([]);
+            localStorage.setItem("user_pins", JSON.stringify([]));
+        }}>
+            Clear pins
+        </button>
+    );
+}


### PR DESCRIPTION
Added 3 new buttons to allow users to manage pins easier
- User can now clear all pins easily
- Users can backup and save / export their pins for easy sharing
- Users can now import other peoples exported pins (note: this overwrites their current ones)

![2024-12-24-101313_grim](https://github.com/user-attachments/assets/c08f10c9-61bc-4cdd-b789-5edcb1b2a943)
