### PR TITLE
fix: Update Food title bcs there was Resource twice

### DIFF
--- a/src/components/IslandInfo.tsx
+++ b/src/components/IslandInfo.tsx
@@ -91,7 +91,7 @@ export default function IslandInfo() {
                 </div>
             </div>
             <div className="flex flex-col mb-5">
-                <h3 className="text-md font-bold mb-2">Resources</h3>
+                <h3 className="text-md font-bold mb-2">Food</h3>
                 <div className="flex flex-wrap gap-2">
                     {
                         current_island[selected_island]?.food?.map(food => {


### PR DESCRIPTION
Self-explanatory, the Food title for the food available in each biome was named Resources (dumb copy/paste).
I don't know how it made up in the main PR, I double-checked every pixel of the interface :(
(fun fact I almost committed a version where I renamed the actual resource list "Food" instead, luckily I tabbed in my browser and realized my mistake just in time)